### PR TITLE
Support for next/previous on non-apple keyboards

### DIFF
--- a/BeotsMusic/AppDelegate.m
+++ b/BeotsMusic/AppDelegate.m
@@ -327,6 +327,15 @@
 			case NX_KEYTYPE_REWIND:
                 [self prev];
 				break;
+                
+            case NX_KEYTYPE_PREVIOUS:
+                [self prev];
+                break;
+                
+            case NX_KEYTYPE_NEXT:
+                [self next];
+                break;
+                
 			default:
 				NSLog(@"Key %d pressed", keyCode);
 				break;


### PR DESCRIPTION
Listen for NX_KEYTYPE_PREVIOUS, NX_KEYTYPE_NEXT to support non-apple keyboards. I've tested this on 2 keyboards and it seems to work. 